### PR TITLE
Implementing Keypair Restoration Functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,21 @@ assert!(keys.public.len() == PUBLICKEYBYTES);
 assert!(keys.expose_secret().len() == SECRETKEYBYTES);
 ```
 
+### Restoring a Keypair
+```rust
+use pqc_dilithium::*;
+use crate::params::{PUBLICKEYBYTES, SECRETKEYBYTES};
+use std::convert::TryInto;
+
+// Assuming you have public and secret key bytes
+let public_bytes: Vec<u8> = vec![0u8; PUBLICKEYBYTES]; // Example byte vectors
+let secret_bytes: Vec<u8> = vec![0u8; SECRETKEYBYTES];
+
+// Restore the keypair
+let restored_keypair = Keypair::new(public_bytes, secret_bytes);
+assert!(restored_keypair.is_ok());
+```
+
 ### Signing 
 ```rust
 let msg = "Hello".as_bytes();

--- a/src/api.rs
+++ b/src/api.rs
@@ -1,3 +1,5 @@
+use std::convert::TryInto;
+
 use crate::params::{PUBLICKEYBYTES, SECRETKEYBYTES, SIGNBYTES};
 use crate::sign::*;
 
@@ -16,10 +18,38 @@ impl std::fmt::Debug for Keypair {
 
 pub enum SignError {
   Input,
+  ConversionFailed,
   Verify,
 }
 
 impl Keypair {
+  /// Constructs a new `Keypair` from public and secret key bytes.
+  ///
+  /// # Errors
+  /// Returns `SignError::ConversionFailed` if the byte vectors are not of the expected length.
+  ///
+  /// # Example
+  /// ```
+  /// # use pqc_dilithium::*;
+  /// # use crate::params::{PUBLICKEYBYTES, SECRETKEYBYTES};
+  /// let public = vec![0u8; PUBLICKEYBYTES];
+  /// let secret = vec![0u8; SECRETKEYBYTES];
+  /// let keypair = Keypair::new(public, secret);
+  /// assert!(keypair.is_ok());
+  /// ```
+  pub fn new(
+    pub_bytes: Vec<u8>,
+    sec_bytes: Vec<u8>,
+  ) -> Result<Self, SignError> {
+    let public = pub_bytes
+      .try_into()
+      .map_err(|_| SignError::ConversionFailed)?;
+    let secret = sec_bytes
+      .try_into()
+      .map_err(|_| SignError::ConversionFailed)?;
+    Ok(Self { public, secret })
+  }
+
   /// Explicitly expose secret key
   /// ```
   /// # use pqc_dilithium::*;


### PR DESCRIPTION
**Overview:**

This Pull Request addresses Issue #11 . The issue highlights the absence of a functionality to save and restore Keypair instances, which is a critical feature for many applications, particularly those requiring key persistence across sessions or environments.

**Changes:**

1. **Implementation of Keypair::new Method:**

- Following the community member's suggestion, i've implemented the restore method within the Keypair struct. This method allows the creation of a Keypair object from separate byte vectors for the public and private keys.
- The method is straightforward to use: it takes two Vec<u8> arguments, one for the public key and one for the private key, and constructs a Keypair object.

2. **Improving Usability and Flexibility:**

- The addition of the restore method significantly increases the library's usability, particularly in scenarios where keys need to be stored and later reconstructed, such as in distributed systems, backups, or when transferring keys between different parts of a system.