### PR TITLE
Small API update

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ use pqc_dilithium::*;
 ### Key Generation
 ```rust
 let keys = Keypair::generate();
-assert!(keys.public.len() == PUBLICKEYBYTES);
+assert!(keys.public().len() == PUBLICKEYBYTES);
 assert!(keys.expose_secret().len() == SECRETKEYBYTES);
 ```
 
@@ -47,7 +47,7 @@ assert!(sig.len() == SIGNBYTES);
 
 ### Verification
 ```rust
-let sig_verify = verify(&sig, &msg, &keys.public);
+let sig_verify = verify(&sig, &msg, &keys.public());
 assert!(sig_verify.is_ok());
 ```
 

--- a/benches/api.rs
+++ b/benches/api.rs
@@ -14,7 +14,7 @@ fn verify_small_msg(c: &mut Criterion) {
   let msg = "Hello".as_bytes();
   let sig = keys.sign(msg);
   c.bench_function("Verify Small Message", |b| {
-    b.iter(|| verify(black_box(sig), black_box(msg), black_box(&keys.public)))
+    b.iter(|| verify(black_box(sig), black_box(msg), black_box(&keys.public())))
   });
 }
 

--- a/src/api.rs
+++ b/src/api.rs
@@ -53,11 +53,11 @@ impl Keypair {
   /// assert!(keys.public().len() == PUBLICKEYBYTES);
   /// assert!(keys.expose_secret().len() == SECRETKEYBYTES);
   /// ```
-  pub fn generate() -> Keypair {
+  pub fn generate() -> Self {
     let mut public = [0u8; PUBLICKEYBYTES];
     let mut secret = [0u8; SECRETKEYBYTES];
     crypto_sign_keypair(&mut public, &mut secret, None);
-    Keypair { public, secret }
+    Self { public, secret }
   }
 
   /// Generates a keypair for signing and verification using a rng
@@ -70,7 +70,7 @@ impl Keypair {
   /// assert!(keys.public().len() == PUBLICKEYBYTES);
   /// assert!(keys.expose_secret().len() == SECRETKEYBYTES);
   /// ```
-  pub fn random(rng: &mut impl CryptoRngCore) -> Keypair {
+  pub fn random(rng: &mut impl CryptoRngCore) -> Self {
     let mut public = [0u8; PUBLICKEYBYTES];
     let mut secret = [0u8; SECRETKEYBYTES];
 
@@ -78,7 +78,7 @@ impl Keypair {
     rng.fill_bytes(&mut seed);
 
     crypto_sign_keypair(&mut public, &mut secret, Some(&seed));
-    Keypair { public, secret }
+    Self { public, secret }
   }
 
   /// Generates a signature for the given message using a keypair
@@ -97,6 +97,19 @@ impl Keypair {
     sig
   }
 
+  /// Get Keypair struct from raw bytes
+  ///
+  /// Example:
+  /// ```
+  /// # use pqc_dilithium::*;
+  /// # let keys = Keypair::generate();
+  /// let public_key = keys.public();
+  /// let secret_key = keys.expose_secret();
+  /// let keys = Keypair::from_bytes(public_key, secret_key);
+  /// # let msg = "Hello".as_bytes();
+  /// # let signature = keys.sign(msg);
+  /// # assert!(verify(&signature, msg, &keys.public()).is_ok());
+  /// ```
   pub fn from_bytes(public_key: &[u8], secret_key: &[u8]) -> Self {
     let mut public = [0u8; PUBLICKEYBYTES];
     let mut secret = [0u8; SECRETKEYBYTES];

--- a/src/api.rs
+++ b/src/api.rs
@@ -1,5 +1,7 @@
+use rand_core::CryptoRngCore;
+
 use crate::params::{PUBLICKEYBYTES, SECRETKEYBYTES, SIGNBYTES};
-use crate::sign::*;
+use crate::{sign::*, SEEDBYTES};
 
 #[derive(Copy, Clone, PartialEq, Eq, Hash)]
 pub struct Keypair {
@@ -55,6 +57,27 @@ impl Keypair {
     let mut public = [0u8; PUBLICKEYBYTES];
     let mut secret = [0u8; SECRETKEYBYTES];
     crypto_sign_keypair(&mut public, &mut secret, None);
+    Keypair { public, secret }
+  }
+
+  /// Generates a keypair for signing and verification using a rng
+  ///
+  /// Example:
+  /// ```
+  /// # use pqc_dilithium::*;
+  /// # use rand_core::OsRng;
+  /// let keys = Keypair::random(&mut OsRng);
+  /// assert!(keys.public().len() == PUBLICKEYBYTES);
+  /// assert!(keys.expose_secret().len() == SECRETKEYBYTES);
+  /// ```
+  pub fn random(rng: &mut impl CryptoRngCore) -> Keypair {
+    let mut public = [0u8; PUBLICKEYBYTES];
+    let mut secret = [0u8; SECRETKEYBYTES];
+
+    let mut seed = [0u8; SEEDBYTES];
+    rng.fill_bytes(&mut seed);
+
+    crypto_sign_keypair(&mut public, &mut secret, Some(&seed));
     Keypair { public, secret }
   }
 

--- a/src/api.rs
+++ b/src/api.rs
@@ -3,7 +3,7 @@ use crate::sign::*;
 
 #[derive(Copy, Clone, PartialEq, Eq, Hash)]
 pub struct Keypair {
-  pub public: [u8; PUBLICKEYBYTES],
+  public: [u8; PUBLICKEYBYTES],
   secret: [u8; SECRETKEYBYTES],
 }
 
@@ -20,6 +20,17 @@ pub enum SignError {
 }
 
 impl Keypair {
+  /// Get public key
+  /// ```
+  /// # use pqc_dilithium::*;
+  /// let keys = Keypair::generate();
+  /// let public_key = keys.public();
+  /// assert!(public_key.len() == PUBLICKEYBYTES);
+  /// ```
+  pub fn public(&self) -> &[u8] {
+    &self.public
+  }
+
   /// Explicitly expose secret key
   /// ```
   /// # use pqc_dilithium::*;
@@ -37,7 +48,7 @@ impl Keypair {
   /// ```
   /// # use pqc_dilithium::*;
   /// let keys = Keypair::generate();
-  /// assert!(keys.public.len() == PUBLICKEYBYTES);
+  /// assert!(keys.public().len() == PUBLICKEYBYTES);
   /// assert!(keys.expose_secret().len() == SECRETKEYBYTES);
   /// ```
   pub fn generate() -> Keypair {
@@ -62,6 +73,16 @@ impl Keypair {
     crypto_sign_signature(&mut sig, msg, &self.secret);
     sig
   }
+
+  pub fn from_bytes(public_key: &[u8], secret_key: &[u8]) -> Self {
+    let mut public = [0u8; PUBLICKEYBYTES];
+    let mut secret = [0u8; SECRETKEYBYTES];
+
+    public.copy_from_slice(public_key);
+    secret.copy_from_slice(secret_key);
+
+    Self { public, secret }
+  }
 }
 
 /// Verify signature using keypair
@@ -72,7 +93,7 @@ impl Keypair {
 /// # let keys = Keypair::generate();
 /// # let msg = [0u8; 32];
 /// # let sig = keys.sign(&msg);
-/// let sig_verify = verify(&sig, &msg, &keys.public);
+/// let sig_verify = verify(&sig, &msg, &keys.public());
 /// assert!(sig_verify.is_ok());
 pub fn verify(
   sig: &[u8],

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -5,7 +5,7 @@ fn sign_then_verify_valid() {
   let msg = b"Hello";
   let keys = Keypair::generate();
   let signature = keys.sign(msg);
-  assert!(verify(&signature, msg, &keys.public).is_ok())
+  assert!(verify(&signature, msg, &keys.public()).is_ok())
 }
 
 #[test]
@@ -14,5 +14,16 @@ fn sign_then_verify_invalid() {
   let keys = Keypair::generate();
   let mut signature = keys.sign(msg);
   signature[..4].copy_from_slice(&[255u8; 4]);
-  assert!(verify(&signature, msg, &keys.public).is_err())
+  assert!(verify(&signature, msg, &keys.public()).is_err())
+}
+
+#[test]
+fn to_and_from_bytes() {
+  let keys = Keypair::generate();
+  let public_key = keys.public();
+  let secret_key = keys.expose_secret();
+  let keys = Keypair::from_bytes(public_key, secret_key);
+  let msg = b"Hello";
+  let signature = keys.sign(msg);
+  assert!(verify(&signature, msg, &keys.public()).is_ok())
 }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -5,7 +5,7 @@ fn sign_then_verify_valid() {
   let msg = b"Hello";
   let keys = Keypair::generate();
   let signature = keys.sign(msg);
-  assert!(verify(&signature, msg, &keys.public()).is_ok())
+  assert!(verify(&signature, msg, &keys.public()).is_ok());
 }
 
 #[test]
@@ -14,7 +14,7 @@ fn sign_then_verify_invalid() {
   let keys = Keypair::generate();
   let mut signature = keys.sign(msg);
   signature[..4].copy_from_slice(&[255u8; 4]);
-  assert!(verify(&signature, msg, &keys.public()).is_err())
+  assert!(verify(&signature, msg, &keys.public()).is_err());
 }
 
 #[test]
@@ -25,5 +25,5 @@ fn to_and_from_bytes() {
   let keys = Keypair::from_bytes(public_key, secret_key);
   let msg = b"Hello";
   let signature = keys.sign(msg);
-  assert!(verify(&signature, msg, &keys.public()).is_ok())
+  assert!(verify(&signature, msg, &keys.public()).is_ok());
 }


### PR DESCRIPTION
Hello, I updated the API a little bit:
1. `Keypair.public` field is now private and the public key can be accessed using `Keypair.public()` function. Now the user can't accidentally modify `public` field.
2. You can save keys to a file and next time read it and use it using `Keypair::from_bytes()` function.
3. More secure rng can be used using `Keypair::random(rng)` function.